### PR TITLE
refactor: improve firmware retrieval logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,9 @@ for later auditing.
 Container Registry, etc).
 
 **OtaFlux verifies signatures before serving firmware to a device, so unsigned
-or
-tampered images are automatically rejected.**
+or tampered images are automatically rejected.**
 
-### Workflow workflow with CoSign
+### Workflow with CoSign
 
 First, you will need both the [Cosign CLI][cosign-cli] and [oras CLI][oras].
 


### PR DESCRIPTION
- The `get_firmware` method was refactored to directly fetch and update the firmware, removing the separate `update` method.
- Error handling for `get_latest_version` was improved to return an error instead of silently falling back to cache. 
- Add content-type header on the /version endpoint.
